### PR TITLE
Add Event Registry concept type to concept table

### DIFF
--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -1,10 +1,11 @@
+import enum
+
 from geoalchemy2 import Geometry
-from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Table
+from sqlalchemy import Column, DateTime, Float, ForeignKey, Integer, String, Table, Enum
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
 from .base import Base
-
 
 class ArticleQuery(Base):
     __tablename__ = "article_queries"
@@ -12,7 +13,6 @@ class ArticleQuery(Base):
     # to be manually inserted
     uuid = Column(UUID(as_uuid=True), primary_key=True)
     body = Column(JSONB, nullable=False)
-
 
 class ArticleUri(Base):
     __tablename__ = "article_uris"
@@ -24,7 +24,6 @@ class ArticleUri(Base):
     page_id = Column(Integer, nullable=False)
     queried_at = Column(DateTime, nullable=False)
     request_id = Column(UUID(as_uuid=True), nullable=False)
-
 
 article_concept_association = Table('article_concept_association', Base.metadata,
     Column('article_uri', String, ForeignKey('article_downloads.uri')),
@@ -44,12 +43,23 @@ class ArticleDownload(Base):
     def __repr__(self):
         return f"<ArticleDownload(uri='{self.uri}')>"
 
+#
+# Event Registry concept data model. See:
+# https://github.com/EventRegistry/event-registry-python/wiki/Data-models#concept-data-model
+#
+
+class ConceptType(enum.Enum):
+    WIKI         = 'wiki'
+    PERSON       = 'person'
+    LOCATION     = 'loc'
+    ORGANIZATION = 'org'
 
 class ConceptUri(Base):
     __tablename__ = "concept_uris"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     concept_uri = Column(String, unique=True, nullable=False)
+    concept_type = Column(Enum(ConceptType, name="concept_enum"), nullable=False)
     geo_names_id = Column(Integer, nullable=True)
     geom = Column(Geometry('POINT', srid=4326), nullable=True)
 


### PR DESCRIPTION
Add concept type to help differentiate Event Registry concepts. The previous table version differentiated concept types by whether geographic features were present. However, if Event Registry has a location type without those features, it would be difficult to distinguish location types from others. This update makes the types explicit.