### PR TITLE
Allow ConceptType enums to be used

### DIFF
--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -88,7 +88,7 @@ class ConceptUri(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     concept_uri = Column(String, unique=True, nullable=False)
-    concept_type = Column(ENUM(ConceptType, name="concept_enum", create_type=True), nullable=False)
+    concept_type = Column(ENUM(ConceptType, name="concept_enum", create_type=False), nullable=False)
     geo_names_id = Column(Integer, nullable=True)
     geom = Column(Geometry("POINT", srid=4326), nullable=True)
 


### PR DESCRIPTION
I was unable to add ConceptType's to the database using SQLAlchemy. For a "wiki" concept type, for example, I tried:

1. ConceptType('wiki')
2. ConceptType('wiki').name
3. ConceptType('wiki').value
4. 'wiki'
5. 'WIKI'

I generally got one of two errors. When using the first or the second methods:

> psycopg2.errors.InvalidTextRepresentation) invalid input value for enum concept_enum: "WIKI"

When using the third or the fourth:

> ConceptType(value).value produces "LookupError: 'wiki' is not among the defined enum values. Enum name: concept_enum. Possible values: WIKI, PERSON, LOCATION, ORGANIZATIO..

I was able to insert into the database when using the raw SQL:

```sql
INSERT INTO public.concept_uris (id, concept_uri, geo_names_id, geom, concept_type)
VALUES (1, 'http://example.org/concept/123', 123456, ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326), 'wiki');
```

After altering the table definition by hand:
```sql
ALTER TABLE public.concept_uris ALTER COLUMN concept_type TYPE TEXT;
DROP TYPE IF EXISTS public.concept_enum;
CREATE TYPE public.concept_enum AS ENUM ('wiki', 'person', 'loc', 'org');
```

I was able to get the Pythonic SQLAlchemy way to work. ChatGPT believes that what I did by hand correlates to having `create_type=False`. Here's its reasoning:

**< ChatGPT >**

Here’s why:
* create_type=True tells SQLAlchemy to create the enum type in the DB based on your Python enum whenever you run migrations or start your app.
* If the DB enum already exists but differs (e.g., casing or values) from your Python enum, SQLAlchemy’s attempt to create or validate the enum type causes conflicts and errors like the ones you saw.

Using create_type=False:
* SQLAlchemy assumes the enum type already exists and matches your Python enum exactly.
* It won’t try to create or modify the enum type.
* This is safer if you manage the enum types manually or via migrations (like Alembic).

So:
* If you want to manage enum types manually (recommended in production), always set create_type=False and sync your Python enum to the actual DB enum type.
* Use create_type=True only for initial development/testing when you want SQLAlchemy to create enums automatically and you know the DB is empty or new.

**< /ChatGPT >**

I have no idea what's going. I'm hoping this fix does the trick