### PR TITLE
Expose article-concept association to clients

### DIFF
--- a/zhai_db_models/__init__.py
+++ b/zhai_db_models/__init__.py
@@ -1,4 +1,11 @@
-from .articles import ArticleDownload, ArticleQuery, ArticleUri, ConceptType, ConceptUri
+from .articles import (
+    ArticleDownload,
+    ArticleQuery,
+    ArticleUri,
+    ConceptType,
+    ConceptUri,
+    article_concept_association,
+)
 from .base import Base
 from .food_security import FoodSecurityDummy
 from .geotaxonomy import (


### PR DESCRIPTION
Add the article-concept association table to the list of exposed assets. This is useful when clients want to insert into the table "manually"; that is, using dictionaries rather than ORM methods like `.concept_uris.extend`