### PR TITLE
db: Convert food insecurity and risk factor score tables into hypertables

### DIFF
--- a/migrations/versions/31304db02105_convert_food_insecurity_and_risk_factor_.py
+++ b/migrations/versions/31304db02105_convert_food_insecurity_and_risk_factor_.py
@@ -1,0 +1,96 @@
+"""Convert food insecurity and risk factor score tables into hypertables
+
+Revision ID: 31304db02105
+Revises: 5e70cbc96191
+Create Date: 2025-10-11 10:45:57.471323
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "31304db02105"
+down_revision: Union[str, Sequence[str], None] = "5e70cbc96191"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Change food_insecurity_scores from incrementing integer pk
+    # to composite pk of (adm_code, year_month)
+    op.drop_constraint(
+        "food_insecurity_scores_pkey", "food_insecurity_scores", type_="primary"
+    )
+    op.drop_constraint(
+        op.f("uq_food_insecurity_scores"), "food_insecurity_scores", type_="unique"
+    )
+
+    op.drop_column("food_insecurity_scores", "id")
+    op.create_primary_key(
+        "pk_food_insecurity_scores",
+        "food_insecurity_scores",
+        ["adm_code", "year_month"],
+    )
+
+    # Change risk_factor_scores from incrementing integer pk
+    # to composite pk of (risk_factor_id, adm_code, year_month)
+    op.drop_constraint(
+        op.f("risk_factor_scores_pkey"), "risk_factor_scores", type_="primary"
+    )
+    op.drop_column("risk_factor_scores", "id")
+    op.drop_constraint(
+        op.f("uq_risk_factor_scores"), "risk_factor_scores", type_="unique"
+    )
+    op.create_primary_key(
+        "pk_risk_factor_scores",
+        "risk_factor_scores",
+        ["adm_code", "year_month", "risk_factor_id"],
+    )
+
+    op.execute("""
+        SELECT create_hypertable('food_insecurity_scores', 'year_month', chunk_time_interval => INTERVAL '1 month', migrate_data => true);
+    """)
+    op.execute("""
+        SELECT create_hypertable('risk_factor_scores', 'year_month', chunk_time_interval => INTERVAL '1 month', migrate_data => true);
+    """)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+
+    # TODO: convert risk_factor_scores and food_insecurity_scores hypertable back to regular table
+    op.drop_constraint("pk_risk_factor_scores", "risk_factor_scores", type_="primary")
+    op.add_column(
+        "risk_factor_scores",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+    )
+    op.create_primary_key(op.f("risk_factor_scores_pkey"), "risk_factor_scores", ["id"])
+    op.create_unique_constraint(
+        op.f("uq_risk_factor_scores"),
+        "risk_factor_scores",
+        ["adm_code", "year_month", "risk_factor_id"],
+        postgresql_nulls_not_distinct=False,
+    )
+
+    op.drop_constraint(
+        "pk_food_insecurity_scores", "food_insecurity_scores", type_="primary"
+    )
+    op.add_column(
+        "food_insecurity_scores",
+        sa.Column(
+            "id", sa.INTEGER(), autoincrement=True, nullable=False, primary_key=True
+        ),
+    )
+    op.create_unique_constraint(
+        op.f("uq_food_insecurity_scores"),
+        "food_insecurity_scores",
+        ["adm_code", "year_month"],
+        postgresql_nulls_not_distinct=False,
+    )
+    op.create_primary_key(
+        op.f("food_insecurity_scores_pkey"), "food_insecurity_scores", ["id"]
+    )

--- a/zhai_db_models/food_security.py
+++ b/zhai_db_models/food_security.py
@@ -5,7 +5,9 @@ from sqlalchemy import (
     Date,
     DateTime,
     ForeignKey,
+    Index,
     Integer,
+    PrimaryKeyConstraint,
     String,
     UniqueConstraint,
     func,
@@ -15,6 +17,7 @@ from sqlalchemy.orm import relationship
 from .base import Base
 
 
+# TODO: delete this table once endpoints are refactored to use FoodInsecurityScore
 class FoodSecurityDummy(Base):
     __tablename__ = "food_security_dummy"
     __table_args__ = (
@@ -36,11 +39,15 @@ class FoodSecurityDummy(Base):
 class FoodInsecurityScore(Base):
     __tablename__ = "food_insecurity_scores"
     __table_args__ = (
+        PrimaryKeyConstraint("adm_code", "year_month", name="pk_food_insecurity_scores"),
         CheckConstraint("EXTRACT(DAY FROM year_month) = 1", name="chk_month_first_day"),
-        UniqueConstraint("year_month", "adm_code", name="uq_food_insecurity_scores")
+        Index(
+            'food_insecurity_scores_year_month_idx',
+            'year_month',
+            info={'skip_autogenerate': True}
+        ),
     )
 
-    id = Column(Integer, primary_key=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
     score = Column(Integer, nullable=False)
@@ -66,11 +73,15 @@ class RiskFactor(Base):
 class RiskFactorScore(Base):
     __tablename__ = "risk_factor_scores"
     __table_args__ = (
+        PrimaryKeyConstraint("risk_factor_id", "adm_code", "year_month", name="pk_risk_factor_scores"),
         CheckConstraint("EXTRACT(DAY FROM year_month) = 1", name="chk_risk_factor_scores_month_first_day"),
-        UniqueConstraint("risk_factor_id", "year_month", "adm_code", name="uq_risk_factor_scores"),
+        Index(
+            'risk_factor_scores_year_month_idx',
+            'year_month',
+            info={'skip_autogenerate': True}
+        ),
     )
 
-    id = Column(Integer, primary_key=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
     risk_factor_id = Column(Integer, ForeignKey("risk_factors.id"), nullable=False)


### PR DESCRIPTION
- Drop incrementing id pks and change it into composite pks comprised of `year_month` (critical for hypertable conversion), `adm_code`, and also `risk_factor_id` for `risk_factor_scores` table
   - Drop uniqueness constraints made redundant by new composite pks 
- Convert `food_insecurity_scores` and `risk_factor_scores` into timescaledb hypertables