### PR TITLE
Table definition for tracking article tags

### DIFF
--- a/migrations/versions/2a6e520c8a0b_add_table_to_track_article_tags.py
+++ b/migrations/versions/2a6e520c8a0b_add_table_to_track_article_tags.py
@@ -20,16 +20,32 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.create_table('tagged_article',
-    sa.Column('article_uri', sa.String(), nullable=False),
-    sa.Column('tag_method_url', sa.String(), nullable=False),
-    sa.ForeignKeyConstraint(['article_uri'], ['article_downloads.uri'], name='fk_tagged_article_article_uri'),
-    sa.PrimaryKeyConstraint('article_uri', 'tag_method_url', name='pk_tagged_article')
+    op.create_table(
+        'tagged_articles',
+        sa.Column(
+            'article_uri',
+            sa.String(),
+            nullable=False,
+        ),
+        sa.Column(
+            'tag_method_url',
+            sa.String(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['article_uri'],
+            ['article_downloads.uri'],
+            name='fk_tagged_articles_article_uri',
+        ),
+        sa.PrimaryKeyConstraint(
+            'article_uri',
+            'tag_method_url',
+            name='pk_tagged_articles',
+        )
     )
-    # ### end Alembic commands ###
 
 
 def downgrade() -> None:
     """Downgrade schema."""
-    op.drop_table('tagged_article')
-    # ### end Alembic commands ###
+    op.drop_table('tagged_articles')
+

--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -184,13 +184,13 @@ class ArticleLocationTags(Base):
     strength = Column(Float)
     tag_method_url = Column(String, nullable=False, primary_key=True)
 
-class TaggedArticle(Base):
-    __tablename__ = "tagged_article"
+class TaggedArticles(Base):
+    __tablename__ = "tagged_articles"
     __table_args__ = (
         PrimaryKeyConstraint(
             "article_uri",
             "tag_method_url",
-            name="pk_tagged_article",
+            name="pk_tagged_articles",
         ),
     )
 
@@ -198,7 +198,7 @@ class TaggedArticle(Base):
         String,
         ForeignKey(
             "article_downloads.uri",
-            name="fk_tagged_article_article_uri",
+            name="fk_tagged_articles_article_uri",
         ),
         nullable=False,
         primary_key=True,


### PR DESCRIPTION
The risk and location tag tables represent URIs that are "positives" for a tag method. There is no way with those tables alone to find out which articles were not hits for a given tag. The table proposed in this PR is mean to that tracks the articles considered by a tagging method; and thus give a sense for the denominator of hits.

Background discussion is in [Slack](https://dime-ai-wb.slack.com/archives/C08PABNE2R1/p1761730292111619).

Notes to reviewers:
* A migration file will be generated once the overall table naming and architecture are reviewed
* Should we consider giving the method its own table, and making this and the tag table associates of it? That would alleviate the awkward implicit foreign key that method currently is