### PR TITLE
[wip] migration: Partition `article_downloads` and repoint tables with foreign key relation to it

### DIFF
--- a/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
+++ b/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
@@ -1,0 +1,55 @@
+"""Create article_downloads_ref table
+
+Revision ID: 6aed76f5eddf
+Revises: bc41f02a2341
+Create Date: 2026-03-30 16:51:12.251351
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '6aed76f5eddf'
+down_revision: Union[str, Sequence[str], None] = 'bc41f02a2341'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('article_downloads_ref',
+        sa.Column('uri', sa.String(), nullable=False),
+        sa.Column('published_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('uri')
+    )
+    op.execute("""
+       CREATE OR REPLACE FUNCTION sync_article_downloads_ref()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF TG_OP = 'INSERT' THEN
+                INSERT INTO article_downloads_ref (id)
+                VALUES (NEW.id)
+                ON CONFLICT DO NOTHING;
+
+            ELSIF TG_OP = 'DELETE' THEN
+                DELETE FROM article_downloads_ref WHERE id = OLD.id;
+            END IF;
+
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+    """)
+    # assumes partitioned articles.article_downloads already exists
+    op.execute("""
+        CREATE TRIGGER article_downloads_ref_sync
+        AFTER INSERT OR DELETE ON article_downloads
+        FOR EACH ROW EXECUTE FUNCTION sync_article_downloads_ref();
+    """)
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("DROP TRIGGER article_downloads_ref_sync ON article_downloads")
+    op.execute("DROP FUNCTION sync_article_downloads_ref()")
+    op.drop_table('article_downloads_ref')

--- a/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
+++ b/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
@@ -49,6 +49,12 @@ def upgrade() -> None:
         sa.Column('published_at', sa.DateTime(), nullable=False),
         sa.PrimaryKeyConstraint('uri')
     )
+    # The following assumes partitioned articles.article_downloads is already backfilled
+    op.execute("""
+        INSERT INTO article_downloads_ref (uri, published_at)
+        SELECT uri, published_at
+        FROM articles.article_downloads
+    """)
     op.execute("""
        CREATE OR REPLACE FUNCTION sync_article_downloads_ref()
         RETURNS TRIGGER AS $$
@@ -71,9 +77,38 @@ def upgrade() -> None:
         AFTER INSERT OR DELETE ON article_downloads
         FOR EACH ROW EXECUTE FUNCTION sync_article_downloads_ref();
     """)
+    for table in ["article_location_tags", "article_risk_factor_tags"]:
+         op.execute(f"""
+            ALTER TABLE {table}
+            DROP CONSTRAINT fk_{table}_article_uri
+        """)
+         op.execute(f"""
+            ALTER TABLE {table}
+            ADD CONSTRAINT fk_{table}_article_uri
+            FOREIGN KEY (article_uri) REFERENCES article_downloads_ref(uri) NOT VALID
+        """)
+        # TODO:
+        # op.execute(f"""
+        #    ALTER TABLE {table} VALIDATE CONSTRAINT fk_{table}_article_uri;
+        # """)
+
 
 def downgrade() -> None:
     """Downgrade schema."""
+    for table in ["article_location_tags", "article_risk_factor_tags"]:
+         op.execute(f"""
+            ALTER TABLE {table}
+            DROP CONSTRAINT fk_{table}_article_uri
+        """)
+         op.execute(f"""
+            ALTER TABLE {table}
+            ADD CONSTRAINT fk_{table}_article_uri
+            FOREIGN KEY (article_uri) REFERENCES public.article_downloads(uri)
+        """)
+        # TODO:
+        # op.execute(f"""
+        #    ALTER TABLE {table} VALIDATE CONSTRAINT fk_{table}_article_uri;
+        # """)
     op.drop_table('articles.article_downloads')
     op.execute("DROP TRIGGER article_downloads_ref_sync ON article_downloads")
     op.execute("DROP FUNCTION sync_article_downloads_ref()")

--- a/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
+++ b/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
@@ -105,10 +105,6 @@ def downgrade() -> None:
             ADD CONSTRAINT fk_{table}_article_uri
             FOREIGN KEY (article_uri) REFERENCES public.article_downloads(uri)
         """)
-        # TODO:
-        # op.execute(f"""
-        #    ALTER TABLE {table} VALIDATE CONSTRAINT fk_{table}_article_uri;
-        # """)
     op.drop_table('articles.article_downloads')
     op.execute("DROP TRIGGER article_downloads_ref_sync ON article_downloads")
     op.execute("DROP FUNCTION sync_article_downloads_ref()")

--- a/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
+++ b/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
@@ -16,6 +16,12 @@ down_revision: Union[str, Sequence[str], None] = 'bc41f02a2341'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
+TABLES_TO_REPOINT = [
+    "article_location_tags",
+    "article_risk_factor_tags",
+    "article_concept_association",
+    "tagged_articles"
+]
 
 def upgrade() -> None:
     """Upgrade schema."""
@@ -74,10 +80,10 @@ def upgrade() -> None:
     """)
     op.execute("""
         CREATE TRIGGER article_downloads_ref_sync
-        AFTER INSERT OR DELETE ON article_downloads
+        BEFORE INSERT OR DELETE ON articles.article_downloads
         FOR EACH ROW EXECUTE FUNCTION sync_article_downloads_ref();
     """)
-    for table in ["article_location_tags", "article_risk_factor_tags"]:
+    for table in TABLES_TO_REPOINT:
          op.execute(f"""
             ALTER TABLE {table}
             DROP CONSTRAINT fk_{table}_article_uri
@@ -95,7 +101,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
-    for table in ["article_location_tags", "article_risk_factor_tags"]:
+    for table in TABLES_TO_REPOINT:
          op.execute(f"""
             ALTER TABLE {table}
             DROP CONSTRAINT fk_{table}_article_uri
@@ -106,6 +112,6 @@ def downgrade() -> None:
             FOREIGN KEY (article_uri) REFERENCES public.article_downloads(uri)
         """)
     op.drop_table('articles.article_downloads')
-    op.execute("DROP TRIGGER article_downloads_ref_sync ON article_downloads")
+    op.execute("DROP TRIGGER article_downloads_ref_sync ON articles.article_downloads")
     op.execute("DROP FUNCTION sync_article_downloads_ref()")
     op.drop_table('article_downloads_ref')

--- a/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
+++ b/migrations/versions/6aed76f5eddf_create_article_downloads_ref_table.py
@@ -19,6 +19,31 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS articles.article_downloads (
+            LIKE public.article_downloads INCLUDING DEFAULTS INCLUDING CONSTRAINTS
+        ) PARTITION BY RANGE (published_at);
+
+        ALTER TABLE articles.article_downloads ADD PRIMARY KEY (uri, published_at);
+
+        WITH bounds AS (
+            SELECT
+                MIN(published_at::date)::text AS start_partition,
+                (
+                    EXTRACT(YEAR FROM age(MAX(published_at::date), MIN(published_at::date))) * 12 +
+                    EXTRACT(MONTH FROM age(MAX(published_at::date), MIN(published_at::date))) + 3
+                )::int AS premake
+            FROM public.article_downloads
+        )
+        SELECT partman.create_parent(
+            p_parent_table    => 'articles.article_downloads',
+            p_control         => 'published_at',
+            p_interval        => '1 month',
+            p_start_partition => bounds.start_partition,
+            p_premake         => bounds.premake
+        )
+        FROM bounds;
+    """)
     op.create_table('article_downloads_ref',
         sa.Column('uri', sa.String(), nullable=False),
         sa.Column('published_at', sa.DateTime(), nullable=False),
@@ -41,7 +66,6 @@ def upgrade() -> None:
         END;
         $$ LANGUAGE plpgsql;
     """)
-    # assumes partitioned articles.article_downloads already exists
     op.execute("""
         CREATE TRIGGER article_downloads_ref_sync
         AFTER INSERT OR DELETE ON article_downloads
@@ -50,6 +74,7 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Downgrade schema."""
+    op.drop_table('articles.article_downloads')
     op.execute("DROP TRIGGER article_downloads_ref_sync ON article_downloads")
     op.execute("DROP FUNCTION sync_article_downloads_ref()")
     op.drop_table('article_downloads_ref')

--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -46,7 +46,7 @@ class ArticleUri(Base):
 article_concept_association = Table(
     "article_concept_association",
     Base.metadata,
-    Column("article_uri", String, ForeignKey("article_downloads.uri", name="fk_article_concept_association_article_uri"), primary_key=True),
+    Column("article_uri", String, ForeignKey("article_downloads_ref.uri", name="fk_article_concept_association_article_uri"), primary_key=True),
     Column("concept_uri", String, ForeignKey("concept_uris.concept_uri", name="fk_article_concept_association_concept_uri"), primary_key=True),
 )
 
@@ -56,7 +56,11 @@ class ArticleType(enum.Enum):
     news = 'news'
 
 class ArticleDownload(Base):
-    __tablename__ = "article_downloads"
+    __tablename__ = "articles.article_downloads"
+    __table_args__ = (
+        {"info": {"skip_autogenerate": True}},
+    )
+
 
     uri = Column(String, primary_key=True)
     url = Column(String, nullable=True)
@@ -77,12 +81,6 @@ class ArticleDownload(Base):
     title = Column(String, nullable=True)
     body = Column(String, nullable=True)
 
-    concept_uris = relationship(
-        "ConceptUri",
-        secondary=article_concept_association,
-        back_populates="article_downloads",
-    )
-
     def __repr__(self):
         return f"<ArticleDownload(uri='{self.uri}')>"
 
@@ -95,6 +93,12 @@ class ArticleDownloadRef(Base):
         primary_key=True,
     )
     published_at = Column(DateTime, nullable=False)
+
+    concept_uris = relationship(
+        "ConceptUri",
+        secondary=article_concept_association,
+        back_populates="article_downloads_ref",
+    )
 
 
 
@@ -162,7 +166,7 @@ class TaggedArticles(Base):
     article_uri = Column(
         String,
         ForeignKey(
-            "article_downloads.uri",
+            "article_downloads_ref.uri",
             name="fk_tagged_articles_article_uri",
         ),
         nullable=False,
@@ -186,7 +190,7 @@ class AbstractArticleTags(Base):
     article_uri = Column(
         String,
         ForeignKey(
-            "article_downloads.uri",
+            "article_downloads_ref.uri",
             name="fk_%(table_name)s_article_uri",
         ),
         nullable=False,

--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -87,6 +87,18 @@ class ArticleDownload(Base):
         return f"<ArticleDownload(uri='{self.uri}')>"
 
 
+class ArticleDownloadRef(Base):
+    __tablename__ = "article_downloads_ref"
+
+    uri = Column(
+        String,
+        primary_key=True,
+    )
+    published_at = Column(DateTime, nullable=False)
+
+
+
+
 #
 # Event Registry concept data model. See:
 # https://github.com/EventRegistry/event-registry-python/wiki/Data-models#concept-data-model

--- a/zhai_db_models/food_insecurity.py
+++ b/zhai_db_models/food_insecurity.py
@@ -110,6 +110,7 @@ class RiskFactorScore(Base):
             "year_month",
             info={"skip_autogenerate": True},
         ),
+        {"info": {"skip_autogenerate": True}},
     )
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())


### PR DESCRIPTION
# ⚠️ Disclaimer
The following migration is already "applied". That is, already stamped on the database.

However, the commands were mostly ran ad-hoc since the some of the backfills and queries (validating repointed constraints) take too long and will likely time out when ran as a migration. So the migration file acts more as a documentation for posterity.

# Premise
A non-negotiable in our use case is to have a partitioned version of `article_downloads`. It will allow the sidebar to fetch articles reasonably fast filtered by year-month chunks. 

<img width="444" height="325" alt="image" src="https://github.com/user-attachments/assets/122661b8-1847-4227-a238-7905833d436f" />

It will also allow us to quickly drop old articles should we decide to set an expiry on what we display on the web app.

# Changelog

To achieve this, we setup a partitioned table `articles.article_downloads` and populate it with the contents of `public.article_downloads`.

However, we have tables that have a previously established foreign key relationship via the `uri` field. Namely, `article_location_tags`, `article_risk_factor_tags`, `article_concept_association`, and `tagged_articles`.

An important limitation of partitioned tables on postgres is that foreign key relationships to it need to have the partitioning field as part of the key.  In our case, we need to add the `published_at` _on top of_ the `uri` field.

As a workaround, we create a non-partitioned bridge table `article_downloads_ref` which only contains `uri` as the pk and `published_at` as an additional field. The four tables above named will then have their foreign key relationships repointed to this bridge table. In turn, the bridge table will be automatically populated whenever we insert to `articles.article_downloads` by using a `TRIGGER`

# Cleanup

We will be renaming `public.article_downloads` into `article_downloads_bak` and then create a view `public.article_downloads` that will act as pass-through to `articles.article_downloads`
