### PR TITLE
Add collected_at to article_downloads

### DIFF
--- a/migrations/versions/8e914964cbf4_add_collected_at_to_article_download.py
+++ b/migrations/versions/8e914964cbf4_add_collected_at_to_article_download.py
@@ -1,0 +1,28 @@
+"""Add collected_at to article_download
+
+Revision ID: 8e914964cbf4
+Revises: 6aed76f5eddf
+Create Date: 2026-04-01 10:09:42.020096
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '8e914964cbf4'
+down_revision: Union[str, Sequence[str], None] = '6aed76f5eddf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_foreign_key('fk_article_concept_association_concept_uri', 'article_concept_association', 'concept_uris', ['concept_uri'], ['concept_uri'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_article_concept_association_concept_uri', 'article_concept_association', type_='foreignkey')

--- a/zhai_db_models/articles.py
+++ b/zhai_db_models/articles.py
@@ -68,6 +68,7 @@ class ArticleDownload(Base):
     cloud_uri = Column(String, unique=True, nullable=False)
     language = Column(String, nullable=False, index=True)
     published_at = Column(DateTime, nullable=False)
+    collected_at = Column(DateTime, default=func.now())
     is_duplicate = Column(Boolean, nullable=True, default=False)
     article_type = Column(
         ENUM(


### PR DESCRIPTION
Adds a collected_at timestamp to the article_downloads table. Handy for tracking when an article was downloaded.